### PR TITLE
feat: エラーハンドリングの強化

### DIFF
--- a/src/agents/agentFactory.ts
+++ b/src/agents/agentFactory.ts
@@ -11,12 +11,14 @@ import { ToolMessage } from "@langchain/core/messages";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import type { Tool } from "@langchain/core/tools";
 import type { z } from "zod";
-import { type AgentRole, createModel } from "@/config.js";
+import { type AgentRole, createModel, getProvider, getRetryConfig } from "@/config.js";
+import { AgentError } from "@/errors/index.js";
 import { logger } from "@/logger.js";
 import { withSpinner } from "@/spinner.js";
 import type { ArticleState } from "@/state.js";
 import { logTokenUsage } from "@/tokenUsage.js";
 import { validatePromptInput } from "@/types/prompts.js";
+import { withModelRetry } from "@/utils/retry.js";
 
 // ============================================================================
 // 型定義
@@ -144,11 +146,14 @@ export function parseRetryResponse(raw: string): {
 /**
  * モデルチェーン実行（スピナー・トークンログ含む）
  *
+ * リトライロジックを含み、APIエラー時に指数バックオフで再試行します。
+ *
  * @param agentName - エージェント名（ログ用）
  * @param modelType - モデル種別
  * @param prompt - チャットプロンプトテンプレート
  * @param input - プロンプト入力値
  * @returns AI応答メッセージ
+ * @throws AgentError リトライ不可能なエラーまたは最大リトライ回数超過時
  */
 export async function executeAgentChain<T extends Record<string, unknown>>(
   agentName: string,
@@ -158,9 +163,25 @@ export async function executeAgentChain<T extends Record<string, unknown>>(
 ): Promise<AIMessage> {
   const model = createModel(modelType);
   const chain = prompt.pipe(model);
-  const result = await withSpinner(`[${agentName}] 思考中...`, () => chain.invoke(input));
-  logTokenUsage(agentName, result as unknown);
-  return result as AIMessage;
+  const provider = getProvider(modelType);
+  const retryConfig = getRetryConfig();
+
+  try {
+    const result = await withModelRetry(
+      () => withSpinner(`[${agentName}] 思考中...`, () => chain.invoke(input)),
+      agentName,
+      provider,
+      retryConfig,
+    );
+    logTokenUsage(agentName, result as unknown);
+    return result as AIMessage;
+  } catch (error) {
+    // AgentError の場合は詳細をログ出力して再スロー
+    if (error instanceof AgentError) {
+      logger.error(`[${agentName}] ${error.toDetailedString()}`);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -177,12 +198,15 @@ const MAX_TOOL_ITERATIONS = 5;
  * 4. ツール結果を ToolMessage として会話履歴に追加
  * 5. モデルに再送信（最終回答まで繰り返し）
  *
+ * 各モデル呼び出しにはリトライロジックが適用されます。
+ *
  * @param agentName - エージェント名（ログ用）
  * @param modelType - モデル種別
  * @param prompt - チャットプロンプトテンプレート
  * @param input - プロンプト入力値
  * @param tools - 使用可能なツール配列
  * @returns AI応答メッセージとツール使用有無
+ * @throws AgentError リトライ不可能なエラーまたは最大リトライ回数超過時
  */
 export async function executeToolEnabledAgentChain<T extends Record<string, unknown>>(
   agentName: string,
@@ -192,6 +216,8 @@ export async function executeToolEnabledAgentChain<T extends Record<string, unkn
   tools: Tool[],
 ): Promise<{ result: AIMessage; toolCallsUsed: boolean }> {
   const model = createModel(modelType);
+  const provider = getProvider(modelType);
+  const retryConfig = getRetryConfig();
 
   logger.debug(`[${agentName}] モデル: ${model.constructor.name}`);
 
@@ -208,80 +234,97 @@ export async function executeToolEnabledAgentChain<T extends Record<string, unkn
   // ツール名→ツールインスタンスのマップ
   const toolMap = new Map(tools.map((t) => [t.name, t]));
 
-  for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
-    // モデル呼び出し
-    const aiMessage = await withSpinner(
-      `[${agentName}] 思考中...${iteration > 0 ? `（ツール実行後 ${iteration}回目）` : ""}`,
-      () => modelWithTools.invoke(messages),
-    ) as AIMessage;
+  try {
+    for (let iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
+      // モデル呼び出し（リトライ付き）
+      const aiMessage = await withModelRetry(
+        () =>
+          withSpinner(
+            `[${agentName}] 思考中...${iteration > 0 ? `（ツール実行後 ${iteration}回目）` : ""}`,
+            () => modelWithTools.invoke(messages),
+          ),
+        agentName,
+        provider,
+        retryConfig,
+      ).then((r) => r as AIMessage);
 
-    logTokenUsage(agentName, aiMessage as unknown);
+      logTokenUsage(agentName, aiMessage as unknown);
 
-    // tool_calls があるか確認
-    const toolCalls = aiMessage.tool_calls ?? [];
-    if (toolCalls.length === 0) {
-      // ツールコールなし → 最終回答として返す
-      return { result: aiMessage, toolCallsUsed };
-    }
-
-    // ツールコールを実行
-    toolCallsUsed = true;
-    logger.info(`[${agentName}] ${toolCalls.length}個のツールコールを実行します`);
-
-    // AIメッセージを会話履歴に追加（tool_calls を含む）
-    messages.push(aiMessage);
-
-    for (const toolCall of toolCalls) {
-      const toolName = toolCall.name;
-      const toolArgs = toolCall.args;
-      const toolCallId = toolCall.id ?? `call_${Date.now()}`;
-
-      logger.info(`[${agentName}]   → ${toolName}(${JSON.stringify(toolArgs).slice(0, 200)})`);
-
-      const tool = toolMap.get(toolName);
-      if (!tool) {
-        logger.warn(`[${agentName}] 未知のツール: ${toolName}`);
-        messages.push(
-          new ToolMessage({
-            content: `エラー: ツール "${toolName}" は利用できません`,
-            tool_call_id: toolCallId,
-          }),
-        );
-        continue;
+      // tool_calls があるか確認
+      const toolCalls = aiMessage.tool_calls ?? [];
+      if (toolCalls.length === 0) {
+        // ツールコールなし → 最終回答として返す
+        return { result: aiMessage, toolCallsUsed };
       }
 
-      try {
-        const toolResult = await tool.invoke(toolArgs);
-        const resultStr = typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult);
-        const truncatedResult = resultStr.length > 300 ? `${resultStr.slice(0, 300)}...` : resultStr;
-        logger.info(`[${agentName}]   ← ${toolName}: ${truncatedResult}`);
+      // ツールコールを実行
+      toolCallsUsed = true;
+      logger.info(`[${agentName}] ${toolCalls.length}個のツールコールを実行します`);
 
-        messages.push(
-          new ToolMessage({
-            content: resultStr,
-            tool_call_id: toolCallId,
-          }),
-        );
-      } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        logger.error(`[${agentName}]   ✗ ${toolName} エラー: ${errorMsg}`);
-        messages.push(
-          new ToolMessage({
-            content: `ツール実行エラー: ${errorMsg}`,
-            tool_call_id: toolCallId,
-          }),
-        );
+      // AIメッセージを会話履歴に追加（tool_calls を含む）
+      messages.push(aiMessage);
+
+      for (const toolCall of toolCalls) {
+        const toolName = toolCall.name;
+        const toolArgs = toolCall.args;
+        const toolCallId = toolCall.id ?? `call_${Date.now()}`;
+
+        logger.info(`[${agentName}]   → ${toolName}(${JSON.stringify(toolArgs).slice(0, 200)})`);
+
+        const tool = toolMap.get(toolName);
+        if (!tool) {
+          logger.warn(`[${agentName}] 未知のツール: ${toolName}`);
+          messages.push(
+            new ToolMessage({
+              content: `エラー: ツール "${toolName}" は利用できません`,
+              tool_call_id: toolCallId,
+            }),
+          );
+          continue;
+        }
+
+        try {
+          const toolResult = await tool.invoke(toolArgs);
+          const resultStr = typeof toolResult === "string" ? toolResult : JSON.stringify(toolResult);
+          const truncatedResult = resultStr.length > 300 ? `${resultStr.slice(0, 300)}...` : resultStr;
+          logger.info(`[${agentName}]   ← ${toolName}: ${truncatedResult}`);
+
+          messages.push(
+            new ToolMessage({
+              content: resultStr,
+              tool_call_id: toolCallId,
+            }),
+          );
+        } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          logger.error(`[${agentName}]   ✗ ${toolName} エラー: ${errorMsg}`);
+          messages.push(
+            new ToolMessage({
+              content: `ツール実行エラー: ${errorMsg}`,
+              tool_call_id: toolCallId,
+            }),
+          );
+        }
       }
     }
+
+    // 最大反復回数到達 → 最後のモデル呼び出し（ツールなし・リトライ付き）
+    logger.warn(`[${agentName}] ツール実行ループが最大回数(${MAX_TOOL_ITERATIONS})に達しました`);
+    const finalResult = await withModelRetry(
+      () => withSpinner(`[${agentName}] 最終応答生成中...`, () => modelWithTools.invoke(messages)),
+      agentName,
+      provider,
+      retryConfig,
+    ).then((r) => r as AIMessage);
+    logTokenUsage(agentName, finalResult as unknown);
+    return { result: finalResult, toolCallsUsed };
+  } catch (error) {
+    // AgentError の場合は詳細をログ出力して再スロー
+    if (error instanceof AgentError) {
+      logger.error(`[${agentName}] ${error.toDetailedString()}`);
+    }
+    throw error;
   }
-
-  // 最大反復回数到達 → 最後のモデル呼び出し（ツールなし）
-  logger.warn(`[${agentName}] ツール実行ループが最大回数(${MAX_TOOL_ITERATIONS})に達しました`);
-  const finalResult = await withSpinner(`[${agentName}] 最終応答生成中...`, () =>
-    modelWithTools.invoke(messages),
-  ) as AIMessage;
-  logTokenUsage(agentName, finalResult as unknown);
-  return { result: finalResult, toolCallsUsed };
 }
 
 // ============================================================================

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import type { BaseChatModel } from "@langchain/core/language_models/chat_models"
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { ChatOpenAI } from "@langchain/openai";
 import { logger } from "@/logger.js";
+import type { RetryConfig } from "@/utils/retry.js";
 
 export type AgentRole = "researcher" | "planner" | "writer" | "editor" | "reviewer";
 
@@ -78,4 +79,50 @@ export function createModel(role: AgentRole): BaseChatModel {
     default:
       throw new Error(`Unknown provider: "${provider}"`);
   }
+}
+
+// ============================================================================
+// リトライ設定
+// ============================================================================
+
+/**
+ * デフォルトのリトライ設定
+ */
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 30000,
+  backoffFactor: 2,
+};
+
+/**
+ * 環境変数からリトライ設定を取得
+ *
+ * 環境変数:
+ * - MAX_RETRIES: 最大リトライ回数（デフォルト: 3）
+ * - RETRY_INITIAL_DELAY_MS: 初期待機時間（デフォルト: 1000）
+ * - RETRY_MAX_DELAY_MS: 最大待機時間（デフォルト: 30000）
+ * - RETRY_BACKOFF_FACTOR: バックオフ係数（デフォルト: 2）
+ *
+ * @returns リトライ設定
+ */
+export function getRetryConfig(): RetryConfig {
+  return {
+    maxRetries: parseInt(process.env.MAX_RETRIES ?? "3", 10),
+    initialDelayMs: parseInt(process.env.RETRY_INITIAL_DELAY_MS ?? "1000", 10),
+    maxDelayMs: parseInt(process.env.RETRY_MAX_DELAY_MS ?? "30000", 10),
+    backoffFactor: parseFloat(process.env.RETRY_BACKOFF_FACTOR ?? "2"),
+  };
+}
+
+/**
+ * 指定されたロールのプロバイダー名を取得
+ *
+ * @param role - エージェントロール
+ * @returns プロバイダー名（openai/gemini/openrouter/glm）
+ */
+export function getProvider(role: AgentRole): string {
+  const raw = process.env[ENV_KEYS[role]] ?? DEFAULTS[role];
+  const { provider } = parseModelString(raw);
+  return provider;
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,241 @@
+/**
+ * エラー分類システム
+ *
+ * LLM API呼び出し時のエラーを分類し、適切な対応アクションを決定するための
+ * カスタムエラークラスと分類定義を提供します。
+ */
+
+/**
+ * エラーの重要度分類
+ */
+export enum ErrorSeverity {
+  /** リトライ可能（一時的なエラー） */
+  RETRYABLE = "retryable",
+  /** 致命的（リトライ不可） */
+  FATAL = "fatal",
+  /** ユーザー設定の問題 */
+  USER_ERROR = "user_error",
+}
+
+/**
+ * エージェント実行時のカスタムエラークラス
+ *
+ * LLM API呼び出しで発生したエラーを分類し、
+ * ユーザーに分かりやすいメッセージと解決策を提供します。
+ */
+export class AgentError extends Error {
+  /** エラーの重要度分類 */
+  public readonly severity: ErrorSeverity;
+  /** エラーが発生したプロバイダー（openai/gemini/openrouter/glm） */
+  public readonly provider?: string;
+  /** 元のエラーオブジェクト */
+  public readonly originalError?: Error;
+  /** 解決策のヒント */
+  public readonly resolutionHint?: string;
+
+  constructor(
+    message: string,
+    severity: ErrorSeverity,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+      resolutionHint?: string;
+    },
+  ) {
+    super(message);
+    this.name = "AgentError";
+    this.severity = severity;
+    this.provider = options?.provider;
+    this.originalError = options?.originalError;
+    this.resolutionHint = options?.resolutionHint;
+
+    // プロトタイプチェーンを正しく設定（TypeScript向け）
+    Object.setPrototypeOf(this, AgentError.prototype);
+  }
+
+  /**
+   * エラーがリトライ可能かどうかを判定
+   */
+  isRetryable(): boolean {
+    return this.severity === ErrorSeverity.RETRYABLE;
+  }
+
+  /**
+   * ユーザー設定の問題かどうかを判定
+   */
+  isUserError(): boolean {
+    return this.severity === ErrorSeverity.USER_ERROR;
+  }
+
+  /**
+   * 致命的なエラーかどうかを判定
+   */
+  isFatal(): boolean {
+    return this.severity === ErrorSeverity.FATAL;
+  }
+
+  /**
+   * 詳細なエラー情報を文字列で取得
+   */
+  toDetailedString(): string {
+    let result = `${this.name}: ${this.message}`;
+    if (this.provider) {
+      result += `\n  プロバイダー: ${this.provider}`;
+    }
+    result += `\n  分類: ${this.severity}`;
+    if (this.resolutionHint) {
+      result += `\n  解決策: ${this.resolutionHint}`;
+    }
+    return result;
+  }
+}
+
+/**
+ * APIレート制限エラー
+ */
+export class RateLimitError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+      retryAfterMs?: number;
+    },
+  ) {
+    super(message, ErrorSeverity.RETRYABLE, {
+      ...options,
+      resolutionHint: "しばらく待ってから再試行してください",
+    });
+    this.name = "RateLimitError";
+    this.retryAfterMs = options?.retryAfterMs;
+    Object.setPrototypeOf(this, RateLimitError.prototype);
+  }
+
+  /** 再試行までの推奨待機時間（ミリ秒） */
+  public readonly retryAfterMs?: number;
+}
+
+/**
+ * 認証エラー
+ */
+export class AuthenticationError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+    },
+  ) {
+    super(message, ErrorSeverity.USER_ERROR, {
+      ...options,
+      resolutionHint: "APIキーが正しく設定されているか確認してください",
+    });
+    this.name = "AuthenticationError";
+    Object.setPrototypeOf(this, AuthenticationError.prototype);
+  }
+}
+
+/**
+ * モデル不存在エラー
+ */
+export class ModelNotFoundError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+    },
+  ) {
+    super(message, ErrorSeverity.USER_ERROR, {
+      ...options,
+      resolutionHint: "モデル名が正しいか確認してください",
+    });
+    this.name = "ModelNotFoundError";
+    Object.setPrototypeOf(this, ModelNotFoundError.prototype);
+  }
+}
+
+/**
+ * ネットワークエラー
+ */
+export class NetworkError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+    },
+  ) {
+    super(message, ErrorSeverity.RETRYABLE, {
+      ...options,
+      resolutionHint: "ネットワーク接続を確認してください",
+    });
+    this.name = "NetworkError";
+    Object.setPrototypeOf(this, NetworkError.prototype);
+  }
+}
+
+/**
+ * タイムアウトエラー
+ */
+export class TimeoutError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+    },
+  ) {
+    super(message, ErrorSeverity.RETRYABLE, {
+      ...options,
+      resolutionHint: "リクエストがタイムアウトしました。再試行します",
+    });
+    this.name = "TimeoutError";
+    Object.setPrototypeOf(this, TimeoutError.prototype);
+  }
+}
+
+/**
+ * 最大リトライ回数超過エラー
+ */
+export class MaxRetriesExceededError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+      attempts: number;
+    },
+  ) {
+    super(message, ErrorSeverity.FATAL, {
+      ...options,
+      resolutionHint: "複数回の再試行が失敗しました。しばらく待ってから再実行してください",
+    });
+    this.name = "MaxRetriesExceededError";
+    this.attempts = options?.attempts ?? 0;
+    Object.setPrototypeOf(this, MaxRetriesExceededError.prototype);
+  }
+
+  /** 試行回数 */
+  public readonly attempts: number;
+}
+
+/**
+ * 不明なエラー
+ */
+export class UnknownProviderError extends AgentError {
+  constructor(
+    message: string,
+    options?: {
+      provider?: string;
+      originalError?: Error;
+    },
+  ) {
+    super(message, ErrorSeverity.USER_ERROR, {
+      ...options,
+      resolutionHint: "プロバイダー名が正しいか確認してください（openai/gemini/openrouter/glm）",
+    });
+    this.name = "UnknownProviderError";
+    Object.setPrototypeOf(this, UnknownProviderError.prototype);
+  }
+}

--- a/src/errors/providerErrors.ts
+++ b/src/errors/providerErrors.ts
@@ -1,0 +1,457 @@
+/**
+ * プロバイダー別エラー処理
+ *
+ * OpenAI, Gemini, OpenRouter, GLM の各プロバイダーが
+ * スローするエラーを分類し、AgentError に変換します。
+ */
+
+import {
+  AgentError,
+  AuthenticationError,
+  ErrorSeverity,
+  MaxRetriesExceededError,
+  ModelNotFoundError,
+  NetworkError,
+  RateLimitError,
+  TimeoutError,
+  UnknownProviderError,
+} from "./index.js";
+
+// ============================================================================
+// 型定義
+// ============================================================================
+
+/**
+ * OpenAI API エラーの構造
+ */
+interface OpenAIErrorLike {
+  status?: number;
+  statusCode?: number;
+  message?: string;
+  error?: {
+    type?: string;
+    message?: string;
+    code?: string;
+  };
+  code?: string;
+}
+
+/**
+ * Google Gemini API エラーの構造
+ */
+interface GeminiErrorLike {
+  status?: string;
+  statusCode?: number;
+  message?: string;
+  details?: Array<{
+    "@type"?: string;
+    reason?: string;
+    metadata?: Record<string, unknown>;
+  }>;
+  code?: number;
+}
+
+/**
+ * 一般的なHTTPエラーの構造
+ */
+interface HttpErrorLike {
+  status?: number;
+  statusCode?: number;
+  statusText?: string;
+  message?: string;
+  code?: string;
+}
+
+// ============================================================================
+// 型ガード関数
+// ============================================================================
+
+/**
+ * OpenAIエラーかどうかを判定
+ */
+function isOpenAIError(error: unknown): error is OpenAIErrorLike {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as Record<string, unknown>;
+  // OpenAI SDK のエラーは status または error.type を持つ
+  return (
+    typeof e.status === "number" ||
+    typeof e.error === "object" ||
+    e.code === "rate_limit_exceeded" ||
+    e.code === "invalid_api_key" ||
+    e.code === "model_not_found"
+  );
+}
+
+/**
+ * Geminiエラーかどうかを判定
+ */
+function isGeminiError(error: unknown): error is GeminiErrorLike {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as Record<string, unknown>;
+  // Google API エラーは status または details を持つ
+  return (
+    typeof e.status === "string" ||
+    Array.isArray(e.details) ||
+    e.status === "RESOURCE_EXHAUSTED" ||
+    e.status === "UNAVAILABLE"
+  );
+}
+
+/**
+ * ネットワークエラーかどうかを判定
+ */
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    const name = error.name?.toLowerCase() ?? "";
+    return (
+      name === "fetcherror" ||
+      message.includes("network") ||
+      message.includes("econnrefused") ||
+      message.includes("enotfound") ||
+      message.includes("econnreset") ||
+      message.includes("socket hang up") ||
+      message.includes("etimedout") ||
+      message.includes("econnaborted")
+    );
+  }
+  return false;
+}
+
+/**
+ * タイムアウトエラーかどうかを判定
+ */
+function isTimeoutError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    return (
+      message.includes("timeout") ||
+      message.includes("timed out") ||
+      message.includes("aborted")
+    );
+  }
+  return false;
+}
+
+// ============================================================================
+// プロバイダー別エラー分類関数
+// ============================================================================
+
+/**
+ * OpenAIエラーを分類
+ */
+function classifyOpenAIError(error: OpenAIErrorLike): AgentError {
+  const status = error.status ?? error.statusCode;
+  const errorMessage = error.error?.message ?? error.message ?? "Unknown error";
+  const errorCode = error.error?.code ?? error.code;
+
+  // HTTPステータスコードによる分類
+  if (status === 429 || errorCode === "rate_limit_exceeded") {
+    return new RateLimitError(`OpenAI APIリクエスト制限に達しました: ${errorMessage}`, {
+      provider: "openai",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 401 || errorCode === "invalid_api_key") {
+    return new AuthenticationError(`OpenAI APIキーが無効です: ${errorMessage}`, {
+      provider: "openai",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 404 || errorCode === "model_not_found") {
+    return new ModelNotFoundError(`OpenAI モデルが見つかりません: ${errorMessage}`, {
+      provider: "openai",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 500 || status === 502 || status === 503) {
+    return new AgentError(
+      `OpenAI サーバーエラー (${status}): ${errorMessage}。再試行します...`,
+      ErrorSeverity.RETRYABLE,
+      {
+        provider: "openai",
+        originalError: error as Error,
+        resolutionHint: "サーバー側の一時的な問題です。しばらく待ってから再試行します",
+      },
+    );
+  }
+
+  if (status === 400) {
+    return new AgentError(
+      `OpenAI リクエストエラー: ${errorMessage}`,
+      ErrorSeverity.USER_ERROR,
+      {
+        provider: "openai",
+        originalError: error as Error,
+        resolutionHint: "リクエストパラメータを確認してください",
+      },
+    );
+  }
+
+  // その他のエラー
+  return new AgentError(`OpenAI API エラー: ${errorMessage}`, ErrorSeverity.FATAL, {
+    provider: "openai",
+    originalError: error as Error,
+  });
+}
+
+/**
+ * Geminiエラーを分類
+ */
+function classifyGeminiError(error: GeminiErrorLike): AgentError {
+  const status = error.status;
+  const errorMessage = error.message ?? "Unknown error";
+
+  // Google API エラーステータスによる分類
+  if (status === "RESOURCE_EXHAUSTED") {
+    return new RateLimitError(`Gemini APIリクエスト制限に達しました: ${errorMessage}`, {
+      provider: "gemini",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === "UNAVAILABLE" || status === "DEADLINE_EXCEEDED") {
+    return new AgentError(
+      `Gemini サービスが一時的に利用できません: ${errorMessage}`,
+      ErrorSeverity.RETRYABLE,
+      {
+        provider: "gemini",
+        originalError: error as Error,
+        resolutionHint: "一時的な問題です。再試行します",
+      },
+    );
+  }
+
+  if (status === "INVALID_ARGUMENT") {
+    return new AgentError(`Gemini リクエストエラー: ${errorMessage}`, ErrorSeverity.USER_ERROR, {
+      provider: "gemini",
+      originalError: error as Error,
+      resolutionHint: "リクエストパラメータまたはモデル名を確認してください",
+    });
+  }
+
+  if (status === "PERMISSION_DENIED" || status === "UNAUTHENTICATED") {
+    return new AuthenticationError(`Gemini 認証エラー: ${errorMessage}`, {
+      provider: "gemini",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === "NOT_FOUND") {
+    return new ModelNotFoundError(`Gemini モデルが見つかりません: ${errorMessage}`, {
+      provider: "gemini",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === "INTERNAL") {
+    return new AgentError(`Gemini 内部エラー: ${errorMessage}`, ErrorSeverity.RETRYABLE, {
+      provider: "gemini",
+      originalError: error as Error,
+      resolutionHint: "サーバー側の一時的な問題です。再試行します",
+    });
+  }
+
+  // その他のエラー
+  return new AgentError(`Gemini API エラー: ${errorMessage}`, ErrorSeverity.FATAL, {
+    provider: "gemini",
+    originalError: error as Error,
+  });
+}
+
+/**
+ * OpenRouterエラーを分類（OpenAI互換APIのため類似の処理）
+ */
+function classifyOpenRouterError(error: HttpErrorLike): AgentError {
+  const status = error.status ?? error.statusCode;
+  const errorMessage = error.message ?? "Unknown error";
+
+  if (status === 429) {
+    return new RateLimitError(`OpenRouter APIリクエスト制限に達しました: ${errorMessage}`, {
+      provider: "openrouter",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 401) {
+    return new AuthenticationError(`OpenRouter APIキーが無効です: ${errorMessage}`, {
+      provider: "openrouter",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 404) {
+    return new ModelNotFoundError(`OpenRouter モデルが見つかりません: ${errorMessage}`, {
+      provider: "openrouter",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 500 || status === 502 || status === 503) {
+    return new AgentError(
+      `OpenRouter サーバーエラー (${status}): ${errorMessage}`,
+      ErrorSeverity.RETRYABLE,
+      {
+        provider: "openrouter",
+        originalError: error as Error,
+        resolutionHint: "プロキシサーバーの一時的な問題です。再試行します",
+      },
+    );
+  }
+
+  // その他のエラー
+  return new AgentError(`OpenRouter API エラー: ${errorMessage}`, ErrorSeverity.FATAL, {
+    provider: "openrouter",
+    originalError: error as Error,
+  });
+}
+
+/**
+ * GLM (Zhipu AI) エラーを分類
+ */
+function classifyGLMError(error: HttpErrorLike): AgentError {
+  const status = error.status ?? error.statusCode;
+  const errorMessage = error.message ?? "Unknown error";
+
+  if (status === 429) {
+    return new RateLimitError(`GLM APIリクエスト制限に達しました: ${errorMessage}`, {
+      provider: "glm",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 401) {
+    return new AuthenticationError(`GLM APIキーが無効です: ${errorMessage}`, {
+      provider: "glm",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 404) {
+    return new ModelNotFoundError(`GLM モデルが見つかりません: ${errorMessage}`, {
+      provider: "glm",
+      originalError: error as Error,
+    });
+  }
+
+  if (status === 500 || status === 502 || status === 503) {
+    return new AgentError(
+      `GLM サーバーエラー (${status}): ${errorMessage}`,
+      ErrorSeverity.RETRYABLE,
+      {
+        provider: "glm",
+        originalError: error as Error,
+        resolutionHint: "サーバー側の一時的な問題です。再試行します",
+      },
+    );
+  }
+
+  // その他のエラー
+  return new AgentError(`GLM API エラー: ${errorMessage}`, ErrorSeverity.FATAL, {
+    provider: "glm",
+    originalError: error as Error,
+  });
+}
+
+// ============================================================================
+// メイン関数
+// ============================================================================
+
+/**
+ * エラーを分類して AgentError に変換
+ *
+ * @param error - 元のエラーオブジェクト
+ * @param provider - プロバイダー名（openai/gemini/openrouter/glm）
+ * @returns 分類された AgentError
+ */
+export function classifyError(error: unknown, provider: string): AgentError {
+  // すでに AgentError の場合はそのまま返す
+  if (error instanceof AgentError) {
+    return error;
+  }
+
+  // ネットワークエラーのチェック（プロバイダー共通）
+  if (isNetworkError(error)) {
+    return new NetworkError(
+      `ネットワークエラー: ${error instanceof Error ? error.message : String(error)}`,
+      { provider, originalError: error instanceof Error ? error : undefined },
+    );
+  }
+
+  // タイムアウトエラーのチェック（プロバイダー共通）
+  if (isTimeoutError(error)) {
+    return new TimeoutError(
+      `リクエストタイムアウト: ${error instanceof Error ? error.message : String(error)}`,
+      { provider, originalError: error instanceof Error ? error : undefined },
+    );
+  }
+
+  // プロバイダー別の分類
+  switch (provider) {
+    case "openai":
+      if (isOpenAIError(error)) {
+        return classifyOpenAIError(error);
+      }
+      break;
+
+    case "gemini":
+      if (isGeminiError(error)) {
+        return classifyGeminiError(error);
+      }
+      // Geminiエラーの形式が異なる場合のフォールバック
+      if (isOpenAIError(error)) {
+        return classifyOpenAIError(error);
+      }
+      break;
+
+    case "openrouter":
+      if (isOpenAIError(error)) {
+        return classifyOpenRouterError(error);
+      }
+      break;
+
+    case "glm":
+      if (isOpenAIError(error)) {
+        return classifyGLMError(error);
+      }
+      break;
+
+    default:
+      return new UnknownProviderError(
+        `不明なプロバイダー: ${provider}`,
+        { provider, originalError: error instanceof Error ? error : undefined },
+      );
+  }
+
+  // 不明なエラー形式の場合
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return new AgentError(`予期しないエラー: ${errorMessage}`, ErrorSeverity.FATAL, {
+    provider,
+    originalError: error instanceof Error ? error : undefined,
+  });
+}
+
+/**
+ * エラーがリトライ可能かどうかを判定
+ *
+ * @param error - エラーオブジェクト
+ * @param provider - プロバイダー名
+ * @returns リトライ可能な場合は true
+ */
+export function isRetryableError(error: unknown, provider: string): boolean {
+  const classified = classifyError(error, provider);
+  return classified.isRetryable();
+}
+
+/**
+ * 解決策のヒントを取得
+ *
+ * @param error - AgentError インスタンス
+ * @returns 解決策の文字列
+ */
+export function getResolutionHint(error: AgentError): string {
+  return error.resolutionHint ?? "管理者に連絡してください";
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,5 @@
+import type { AgentError } from "@/errors/index.js";
+
 const LOG_LEVELS = ["error", "warn", "info", "debug"] as const;
 type LogLevel = (typeof LOG_LEVELS)[number];
 
@@ -7,6 +9,31 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
   info: 2,
   debug: 3,
 };
+
+/**
+ * AgentError かどうかを型ガードで判定
+ */
+function isAgentError(error: unknown): error is AgentError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "toDetailedString" in error &&
+    typeof (error as AgentError).toDetailedString === "function"
+  );
+}
+
+/**
+ * エラーから詳細情報を取得
+ */
+function formatError(error: unknown): string {
+  if (isAgentError(error)) {
+    return error.toDetailedString();
+  }
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
 
 export class Logger {
   private level: LogLevel;
@@ -20,7 +47,31 @@ export class Logger {
     return LEVEL_PRIORITY[level] <= LEVEL_PRIORITY[this.level];
   }
 
-  error(...args: unknown[]): void {
+  /**
+   * エラーログ出力
+   *
+   * AgentError の場合は詳細情報（分類、プロバイダー、解決策）を含めて出力します。
+   *
+   * @param message - ログメッセージ
+   * @param error - エラーオブジェクト（オプション）
+   */
+  error(message: string, error?: unknown): void {
+    if (this.shouldLog("error")) {
+      const timestamp = new Date().toISOString();
+      if (error !== undefined) {
+        console.error(`[${timestamp}] [ERROR] ${message}\n  ${formatError(error)}`);
+      } else {
+        console.error(`[${timestamp}] [ERROR] ${message}`);
+      }
+    }
+  }
+
+  /**
+   * 従来のエラーログ（可変長引数）
+   *
+   * @deprecated error(message, error) の使用を推奨
+   */
+  errorLegacy(...args: unknown[]): void {
     if (this.shouldLog("error")) console.error("[ERROR]", ...args);
   }
 
@@ -34,6 +85,20 @@ export class Logger {
 
   debug(...args: unknown[]): void {
     if (this.shouldLog("debug")) console.log("[DEBUG]", ...args);
+  }
+
+  /**
+   * リトライ状況のログ出力
+   *
+   * @param agentName - エージェント名
+   * @param attempt - 試行回数
+   * @param maxRetries - 最大リトライ回数
+   * @param error - エラーオブジェクト
+   * @param delayMs - 待機時間（ミリ秒）
+   */
+  retry(agentName: string, attempt: number, maxRetries: number, error: Error, delayMs: number): void {
+    this.warn(`[${agentName}] リトライ ${attempt}/${maxRetries}: ${error.message}`);
+    this.info(`[${agentName}] ${(delayMs / 1000).toFixed(1)}秒待機中...`);
   }
 }
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,165 @@
+/**
+ * リトライポリシーと指数バックオフ
+ *
+ * LLM API呼び出し時の一時的なエラーに対して、
+ * 指数バックオフによるリトライを実行します。
+ */
+
+import { MaxRetriesExceededError } from "@/errors/index.js";
+import { classifyError } from "@/errors/providerErrors.js";
+import { logger } from "@/logger.js";
+
+// ============================================================================
+// 型定義
+// ============================================================================
+
+/**
+ * リトライ設定
+ */
+export interface RetryConfig {
+  /** 最大リトライ回数 */
+  maxRetries: number;
+  /** 初期待機時間（ミリ秒） */
+  initialDelayMs: number;
+  /** 最大待機時間（ミリ秒） */
+  maxDelayMs: number;
+  /** バックオフ係数 */
+  backoffFactor: number;
+}
+
+/**
+ * リトライ時のコールバック関数
+ */
+export type RetryCallback = (
+  attempt: number,
+  error: Error,
+  delayMs: number,
+) => void;
+
+// ============================================================================
+// デフォルト設定
+// ============================================================================
+
+/**
+ * デフォルトのリトライ設定
+ */
+export const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 30000,
+  backoffFactor: 2,
+};
+
+// ============================================================================
+// ユーティリティ関数
+// ============================================================================
+
+/**
+ * 指定時間待機
+ *
+ * @param ms - 待機時間（ミリ秒）
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * 指数バックオフの待機時間を計算
+ *
+ * @param attempt - 現在の試行回数（0始まり）
+ * @param config - リトライ設定
+ * @returns 待機時間（ミリ秒）
+ */
+export function calculateBackoffDelay(attempt: number, config: RetryConfig): number {
+  const delay = config.initialDelayMs * Math.pow(config.backoffFactor, attempt);
+  return Math.min(delay, config.maxDelayMs);
+}
+
+// ============================================================================
+// メイン関数
+// ============================================================================
+
+/**
+ * リトライロジック付きで関数を実行
+ *
+ * @param fn - 実行する非同期関数
+ * @param config - リトライ設定
+ * @param provider - プロバイダー名（エラー分類用）
+ * @param onRetry - リトライ時のコールバック（オプション）
+ * @returns 関数の実行結果
+ * @throws MaxRetriesExceededError 最大リトライ回数を超えた場合
+ * @throws AgentError リトライ不可能なエラーの場合
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  config: RetryConfig,
+  provider: string,
+  onRetry?: RetryCallback,
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= config.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      // エラーを分類
+      const classified = classifyError(error, provider);
+
+      // リトライ不可能なエラーは即座にスロー
+      if (!classified.isRetryable()) {
+        throw classified;
+      }
+
+      lastError = classified;
+
+      // 最大リトライ回数に達した場合
+      if (attempt === config.maxRetries) {
+        throw new MaxRetriesExceededError(
+          `${provider} API: 最大リトライ回数(${config.maxRetries})を超えました`,
+          {
+            provider,
+            originalError: classified,
+            attempts: attempt + 1,
+          },
+        );
+      }
+
+      // バックオフ時間を計算
+      const delay = calculateBackoffDelay(attempt, config);
+
+      // リトライコールバックを実行
+      if (onRetry) {
+        onRetry(attempt + 1, classified, delay);
+      }
+
+      // 待機
+      await sleep(delay);
+    }
+  }
+
+  // ここには到達しないはずだが、TypeScriptの型チェックのため
+  throw lastError ?? new Error("Unexpected error in retry logic");
+}
+
+/**
+ * モデル呼び出し用のリトライラッパー
+ *
+ * エージェント名を含むログ出力を行い、リトライ状況を分かりやすく表示します。
+ *
+ * @param fn - モデル呼び出し関数
+ * @param agentName - エージェント名
+ * @param provider - プロバイダー名
+ * @param config - リトライ設定
+ * @returns モデル呼び出しの結果
+ */
+export async function withModelRetry<T>(
+  fn: () => Promise<T>,
+  agentName: string,
+  provider: string,
+  config: RetryConfig = DEFAULT_RETRY_CONFIG,
+): Promise<T> {
+  return withRetry(fn, config, provider, (attempt, error, delay) => {
+    logger.warn(`[${agentName}] リトライ ${attempt}/${config.maxRetries}: ${error.message}`);
+    logger.info(`[${agentName}] ${(delay / 1000).toFixed(1)}秒待機中...`);
+  });
+}

--- a/tests/unit/errors/providerErrors.test.ts
+++ b/tests/unit/errors/providerErrors.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "bun:test";
+import {
+  classifyError,
+  isRetryableError,
+  getResolutionHint,
+} from "@/errors/providerErrors.js";
+import {
+  AgentError,
+  ErrorSeverity,
+  RateLimitError,
+  AuthenticationError,
+  ModelNotFoundError,
+  NetworkError,
+  TimeoutError,
+} from "@/errors/index.js";
+
+describe("providerErrors", () => {
+  describe("classifyError - OpenAI", () => {
+    it("429エラーは RateLimitError に分類される", () => {
+      const error = { status: 429, message: "Rate limit exceeded" };
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(RateLimitError);
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+      expect(result.provider).toBe("openai");
+    });
+
+    it("401エラーは AuthenticationError に分類される", () => {
+      const error = { status: 401, message: "Invalid API key" };
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(AuthenticationError);
+      expect(result.severity).toBe(ErrorSeverity.USER_ERROR);
+      expect(result.provider).toBe("openai");
+    });
+
+    it("404エラーは ModelNotFoundError に分類される", () => {
+      const error = { status: 404, message: "Model not found" };
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(ModelNotFoundError);
+      expect(result.severity).toBe(ErrorSeverity.USER_ERROR);
+    });
+
+    it("500エラーは RETRYABLE に分類される", () => {
+      const error = { status: 500, message: "Internal server error" };
+      const result = classifyError(error, "openai");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+      expect(result.message).toContain("サーバーエラー");
+    });
+
+    it("502エラーは RETRYABLE に分類される", () => {
+      const error = { status: 502, message: "Bad gateway" };
+      const result = classifyError(error, "openai");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+    });
+
+    it("503エラーは RETRYABLE に分類される", () => {
+      const error = { status: 503, message: "Service unavailable" };
+      const result = classifyError(error, "openai");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+    });
+
+    it("400エラーは USER_ERROR に分類される", () => {
+      const error = { status: 400, message: "Bad request" };
+      const result = classifyError(error, "openai");
+
+      expect(result.severity).toBe(ErrorSeverity.USER_ERROR);
+    });
+
+    it("rate_limit_exceeded コードは RateLimitError に分類される", () => {
+      const error = { code: "rate_limit_exceeded", message: "Rate limit" };
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(RateLimitError);
+    });
+  });
+
+  describe("classifyError - Gemini", () => {
+    it("RESOURCE_EXHAUSTED は RateLimitError に分類される", () => {
+      const error = { status: "RESOURCE_EXHAUSTED", message: "Quota exceeded" };
+      const result = classifyError(error, "gemini");
+
+      expect(result).toBeInstanceOf(RateLimitError);
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+      expect(result.provider).toBe("gemini");
+    });
+
+    it("UNAVAILABLE は RETRYABLE に分類される", () => {
+      const error = { status: "UNAVAILABLE", message: "Service temporarily unavailable" };
+      const result = classifyError(error, "gemini");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+      expect(result.message).toContain("一時的に利用できません");
+    });
+
+    it("DEADLINE_EXCEEDED は RETRYABLE に分類される", () => {
+      const error = { status: "DEADLINE_EXCEEDED", message: "Deadline exceeded" };
+      const result = classifyError(error, "gemini");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+    });
+
+    it("INVALID_ARGUMENT は USER_ERROR に分類される", () => {
+      const error = { status: "INVALID_ARGUMENT", message: "Invalid argument" };
+      const result = classifyError(error, "gemini");
+
+      expect(result.severity).toBe(ErrorSeverity.USER_ERROR);
+    });
+
+    it("PERMISSION_DENIED は AuthenticationError に分類される", () => {
+      const error = { status: "PERMISSION_DENIED", message: "Permission denied" };
+      const result = classifyError(error, "gemini");
+
+      expect(result).toBeInstanceOf(AuthenticationError);
+    });
+
+    it("UNAUTHENTICATED は AuthenticationError に分類される", () => {
+      const error = { status: "UNAUTHENTICATED", message: "Unauthenticated" };
+      const result = classifyError(error, "gemini");
+
+      expect(result).toBeInstanceOf(AuthenticationError);
+    });
+
+    it("NOT_FOUND は ModelNotFoundError に分類される", () => {
+      const error = { status: "NOT_FOUND", message: "Model not found" };
+      const result = classifyError(error, "gemini");
+
+      expect(result).toBeInstanceOf(ModelNotFoundError);
+    });
+
+    it("INTERNAL は RETRYABLE に分類される", () => {
+      const error = { status: "INTERNAL", message: "Internal error" };
+      const result = classifyError(error, "gemini");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+    });
+  });
+
+  describe("classifyError - OpenRouter", () => {
+    it("429エラーは RateLimitError に分類される", () => {
+      const error = { status: 429, message: "Rate limit exceeded" };
+      const result = classifyError(error, "openrouter");
+
+      expect(result).toBeInstanceOf(RateLimitError);
+      expect(result.provider).toBe("openrouter");
+    });
+
+    it("401エラーは AuthenticationError に分類される", () => {
+      const error = { status: 401, message: "Invalid API key" };
+      const result = classifyError(error, "openrouter");
+
+      expect(result).toBeInstanceOf(AuthenticationError);
+    });
+
+    it("500エラーは RETRYABLE に分類される", () => {
+      const error = { status: 500, message: "Server error" };
+      const result = classifyError(error, "openrouter");
+
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+      expect(result.resolutionHint).toContain("プロキシサーバー");
+    });
+  });
+
+  describe("classifyError - GLM", () => {
+    it("429エラーは RateLimitError に分類される", () => {
+      const error = { status: 429, message: "Rate limit exceeded" };
+      const result = classifyError(error, "glm");
+
+      expect(result).toBeInstanceOf(RateLimitError);
+      expect(result.provider).toBe("glm");
+    });
+
+    it("401エラーは AuthenticationError に分類される", () => {
+      const error = { status: 401, message: "Invalid API key" };
+      const result = classifyError(error, "glm");
+
+      expect(result).toBeInstanceOf(AuthenticationError);
+    });
+  });
+
+  describe("classifyError - ネットワークエラー", () => {
+    it("network エラーメッセージは NetworkError に分類される", () => {
+      const error = new Error("network error");
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(NetworkError);
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+    });
+
+    it("ECONNREFUSED は NetworkError に分類される", () => {
+      const error = new Error("ECONNREFUSED");
+      const result = classifyError(error, "gemini");
+
+      expect(result).toBeInstanceOf(NetworkError);
+    });
+
+    it("ENOTFOUND は NetworkError に分類される", () => {
+      const error = new Error("ENOTFOUND api.openai.com");
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(NetworkError);
+    });
+  });
+
+  describe("classifyError - タイムアウトエラー", () => {
+    it("timeout エラーメッセージは TimeoutError に分類される", () => {
+      const error = new Error("Request timeout");
+      const result = classifyError(error, "openai");
+
+      expect(result).toBeInstanceOf(TimeoutError);
+      expect(result.severity).toBe(ErrorSeverity.RETRYABLE);
+    });
+
+    it("timed out は TimeoutError に分類される", () => {
+      const error = new Error("Request timed out after 30000ms");
+      const result = classifyError(error, "gemini");
+
+      expect(result).toBeInstanceOf(TimeoutError);
+    });
+  });
+
+  describe("classifyError - 既存のAgentError", () => {
+    it("既に AgentError の場合はそのまま返す", () => {
+      const originalError = new AgentError("Original error", ErrorSeverity.FATAL, {
+        provider: "openai",
+      });
+      const result = classifyError(originalError, "openai");
+
+      expect(result).toBe(originalError);
+    });
+  });
+
+  describe("classifyError - 不明なエラー", () => {
+    it("不明なプロバイダーの場合は UnknownProviderError", () => {
+      const error = new Error("Some error");
+      const result = classifyError(error, "unknown_provider");
+
+      expect(result.name).toBe("UnknownProviderError");
+    });
+
+    it("不明なエラー形式は FATAL に分類される", () => {
+      const error = { foo: "bar" };
+      const result = classifyError(error, "openai");
+
+      expect(result.severity).toBe(ErrorSeverity.FATAL);
+    });
+  });
+
+  describe("isRetryableError", () => {
+    it("RETRYABLE エラーは true を返す", () => {
+      const error = { status: 429, message: "Rate limit" };
+      expect(isRetryableError(error, "openai")).toBe(true);
+    });
+
+    it("USER_ERROR は false を返す", () => {
+      const error = { status: 401, message: "Invalid API key" };
+      expect(isRetryableError(error, "openai")).toBe(false);
+    });
+
+    it("FATAL は false を返す", () => {
+      const error = { status: 400, message: "Bad request" };
+      // 400はUSER_ERRORなのでfalseになる
+      expect(isRetryableError(error, "openai")).toBe(false);
+    });
+  });
+
+  describe("getResolutionHint", () => {
+    it("resolutionHint がある場合はそれを返す", () => {
+      const error = new AgentError("Error", ErrorSeverity.USER_ERROR, {
+        provider: "openai",
+        resolutionHint: "APIキーを確認してください",
+      });
+      expect(getResolutionHint(error)).toBe("APIキーを確認してください");
+    });
+
+    it("resolutionHint がない場合はデフォルトメッセージを返す", () => {
+      const error = new AgentError("Error", ErrorSeverity.FATAL);
+      expect(getResolutionHint(error)).toBe("管理者に連絡してください");
+    });
+  });
+});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -115,7 +115,7 @@ describe("Logger", () => {
   });
 
   describe("ログ出力のフォーマット", () => {
-    test("errorメッセージに[ERROR]プレフィックス", () => {
+    test("errorメッセージに[ERROR]プレフィックスとタイムスタンプ", () => {
       process.env.LOG_LEVEL = "error";
       const logger = new Logger();
 
@@ -123,7 +123,8 @@ describe("Logger", () => {
       logger.error("test error");
 
       expect(capturedLogs.length).toBe(1);
-      expect(capturedLogs[0].args[0]).toBe("[ERROR]");
+      // 新しいフォーマット: [timestamp] [ERROR] message
+      expect(capturedLogs[0].args[0]).toMatch(/\[.*\] \[ERROR\] test error/);
 
       restoreConsole();
       delete process.env.LOG_LEVEL;
@@ -138,6 +139,7 @@ describe("Logger", () => {
 
       expect(capturedLogs.length).toBe(1);
       expect(capturedLogs[0].args[0]).toBe("[WARN]");
+      expect(capturedLogs[0].args[1]).toBe("test warning");
 
       restoreConsole();
       delete process.env.LOG_LEVEL;
@@ -151,6 +153,7 @@ describe("Logger", () => {
 
       expect(capturedLogs.length).toBe(1);
       expect(capturedLogs[0].args[0]).toBe("[INFO]");
+      expect(capturedLogs[0].args[1]).toBe("test info");
 
       restoreConsole();
     });
@@ -164,6 +167,7 @@ describe("Logger", () => {
 
       expect(capturedLogs.length).toBe(1);
       expect(capturedLogs[0].args[0]).toBe("[DEBUG]");
+      expect(capturedLogs[0].args[1]).toBe("test debug");
 
       restoreConsole();
       delete process.env.LOG_LEVEL;

--- a/tests/unit/utils/retry.test.ts
+++ b/tests/unit/utils/retry.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "bun:test";
+import {
+  withRetry,
+  calculateBackoffDelay,
+  DEFAULT_RETRY_CONFIG,
+  type RetryConfig,
+} from "@/utils/retry.js";
+import { AgentError, ErrorSeverity, MaxRetriesExceededError } from "@/errors/index.js";
+
+describe("retry utils", () => {
+  describe("calculateBackoffDelay", () => {
+    it("初回(attempt=0)は initialDelayMs を返す", () => {
+      const config: RetryConfig = {
+        maxRetries: 3,
+        initialDelayMs: 1000,
+        maxDelayMs: 30000,
+        backoffFactor: 2,
+      };
+      expect(calculateBackoffDelay(0, config)).toBe(1000);
+    });
+
+    it("指数バックオフが正しく計算される", () => {
+      const config: RetryConfig = {
+        maxRetries: 3,
+        initialDelayMs: 1000,
+        maxDelayMs: 30000,
+        backoffFactor: 2,
+      };
+      expect(calculateBackoffDelay(0, config)).toBe(1000); // 1000 * 2^0 = 1000
+      expect(calculateBackoffDelay(1, config)).toBe(2000); // 1000 * 2^1 = 2000
+      expect(calculateBackoffDelay(2, config)).toBe(4000); // 1000 * 2^2 = 4000
+      expect(calculateBackoffDelay(3, config)).toBe(8000); // 1000 * 2^3 = 8000
+    });
+
+    it("最大待機時間を超えない", () => {
+      const config: RetryConfig = {
+        maxRetries: 10,
+        initialDelayMs: 1000,
+        maxDelayMs: 5000,
+        backoffFactor: 2,
+      };
+      expect(calculateBackoffDelay(10, config)).toBe(5000); // 1000 * 2^10 = 1024000 だが maxDelayMs で制限
+    });
+
+    it("異なるバックオフ係数で正しく計算される", () => {
+      const config: RetryConfig = {
+        maxRetries: 3,
+        initialDelayMs: 500,
+        maxDelayMs: 30000,
+        backoffFactor: 3,
+      };
+      expect(calculateBackoffDelay(0, config)).toBe(500); // 500 * 3^0 = 500
+      expect(calculateBackoffDelay(1, config)).toBe(1500); // 500 * 3^1 = 1500
+      expect(calculateBackoffDelay(2, config)).toBe(4500); // 500 * 3^2 = 4500
+    });
+  });
+
+  describe("withRetry", () => {
+    it("成功時は結果をそのまま返す", async () => {
+      const fn = vi.fn().mockResolvedValue("success");
+      const result = await withRetry(fn, DEFAULT_RETRY_CONFIG, "openai");
+      expect(result).toBe("success");
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("リトライ可能なエラーは指定回数リトライする", async () => {
+      const retryableError = new AgentError(
+        "Rate limit",
+        ErrorSeverity.RETRYABLE,
+        { provider: "openai" },
+      );
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(retryableError)
+        .mockRejectedValueOnce(retryableError)
+        .mockResolvedValue("success");
+
+      const onRetry = vi.fn();
+
+      // sleepをモック（Bunの方式）
+      const originalSetTimeout = global.setTimeout;
+      let sleepCallCount = 0;
+      global.setTimeout = ((callback: () => void) => {
+        sleepCallCount++;
+        callback();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout;
+
+      try {
+        const result = await withRetry(fn, DEFAULT_RETRY_CONFIG, "openai", onRetry);
+        expect(result).toBe("success");
+        expect(fn).toHaveBeenCalledTimes(3);
+        expect(onRetry).toHaveBeenCalledTimes(2);
+      } finally {
+        global.setTimeout = originalSetTimeout;
+      }
+    });
+
+    it("最大リトライ回数に達したら MaxRetriesExceededError をスロー", async () => {
+      const retryableError = new AgentError(
+        "Rate limit",
+        ErrorSeverity.RETRYABLE,
+        { provider: "openai" },
+      );
+      const fn = vi.fn().mockRejectedValue(retryableError);
+
+      // sleepをモック
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = ((callback: () => void) => {
+        callback();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout;
+
+      try {
+        await expect(withRetry(fn, DEFAULT_RETRY_CONFIG, "openai")).rejects.toThrow(
+          MaxRetriesExceededError,
+        );
+        expect(fn).toHaveBeenCalledTimes(DEFAULT_RETRY_CONFIG.maxRetries + 1); // 初回 + リトライ3回
+      } finally {
+        global.setTimeout = originalSetTimeout;
+      }
+    });
+
+    it("リトライ不可能なエラーは即座にスロー", async () => {
+      const fatalError = new AgentError(
+        "Authentication failed",
+        ErrorSeverity.USER_ERROR,
+        { provider: "openai" },
+      );
+      const fn = vi.fn().mockRejectedValue(fatalError);
+
+      await expect(withRetry(fn, DEFAULT_RETRY_CONFIG, "openai")).rejects.toThrow(AgentError);
+      expect(fn).toHaveBeenCalledTimes(1); // リトライなし
+    });
+
+    it("FATAL エラーは即座にスロー", async () => {
+      const fatalError = new AgentError("Fatal error", ErrorSeverity.FATAL, { provider: "openai" });
+      const fn = vi.fn().mockRejectedValue(fatalError);
+
+      await expect(withRetry(fn, DEFAULT_RETRY_CONFIG, "openai")).rejects.toThrow(AgentError);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("onRetryコールバックに正しい引数が渡される", async () => {
+      const retryableError = new AgentError(
+        "Rate limit",
+        ErrorSeverity.RETRYABLE,
+        { provider: "openai" },
+      );
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(retryableError)
+        .mockResolvedValue("success");
+
+      const onRetry = vi.fn();
+
+      // sleepをモック
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = ((callback: () => void) => {
+        callback();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout;
+
+      try {
+        await withRetry(fn, DEFAULT_RETRY_CONFIG, "openai", onRetry);
+        expect(onRetry).toHaveBeenCalledWith(1, retryableError, expect.any(Number));
+      } finally {
+        global.setTimeout = originalSetTimeout;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## 概要

LLM API呼び出し時のエラー処理を強化し、指数バックオフによるリトライポリシー、プロバイダー別エラー対応、ユーザー向けエラーメッセージの改善を実装しました。

## 変更内容

### 新規ファイル
- `src/errors/index.ts` - エラー分類システム（ErrorSeverity, AgentError カスタムクラス）
- `src/errors/providerErrors.ts` - プロバイダー別エラー処理（OpenAI, Gemini, OpenRouter, GLM）
- `src/utils/retry.ts` - 指数バックオフによるリトライポリシー
- `tests/unit/utils/retry.test.ts` - リトライロジックのテスト
- `tests/unit/errors/providerErrors.test.ts` - プロバイダーエラー処理のテスト

### 修正ファイル
- `src/config.ts` - リトライ設定関数（getRetryConfig, getProvider）を追加
- `src/agents/agentFactory.ts` - モデル呼び出しにリトライロジックを統合
- `src/logger.ts` - エラーログの強化（タイムスタンプ、詳細情報表示）

## 機能詳細

### 指数バックオフリトライ
- 初期待機時間: 1秒
- 最大待機時間: 30秒
- バックオフ係数: 2
- 環境変数でカスタマイズ可能

### エラー分類
| 分類 | 内容 | 対応 |
|------|------|------|
| RETRYABLE | レート制限、500系エラー、ネットワーク/タイムアウト | 自動リトライ |
| USER_ERROR | 認証エラー、無効なモデル名 | 即時終了 |
| FATAL | その他の回復不可能なエラー | 即時終了 |

### 環境変数
- `MAX_RETRIES` - 最大リトライ回数（デフォルト: 3）
- `RETRY_INITIAL_DELAY_MS` - 初期待機時間（デフォルト: 1000）
- `RETRY_MAX_DELAY_MS` - 最大待機時間（デフォルト: 30000）
- `RETRY_BACKOFF_FACTOR` - バックオフ係数（デフォルト: 2）

## テスト結果

```
214 tests passed
367 expect() calls
```

## Test plan
- [x] 型チェック (`bun run type-check`) が通ること
- [x] 全テスト (`bun run test`) が通ること
- [x] ビルド (`bun run build`) が成功すること
- [ ] 実際のAPI呼び出しでレート制限時にリトライされること（手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)