### PR TITLE
fix: Reviewerエージェントのバリデーションエラー修正

### DIFF
--- a/src/agents/reviewer.ts
+++ b/src/agents/reviewer.ts
@@ -9,8 +9,12 @@ const config: ReviewerAgentConfig<typeof reviewerInputSchema> = {
   humanPromptTemplate: REVIEWER_HUMAN,
   inputSchema: reviewerInputSchema,
   inputExtractor: (state) => ({
+    topic: state.topic,
     outline: state.outline,
+    draft: state.draft,
     editedDraft: state.editedDraft,
+    reviewCount: state.reviewCount ?? 0,
+    maxReviews: state.maxReviews ?? 3,
   }),
 };
 


### PR DESCRIPTION
## Summary

- Reviewerエージェントの `inputExtractor` に不足していたフィールド（`topic`, `draft`, `reviewCount`, `maxReviews`）を追加
- バリデーションエラー「expected string, received undefined」を修正

## 変更内容

`src/agents/reviewer.ts` の `inputExtractor` を修正し、`reviewerInputSchema` で要求されている全フィールドを抽出するように変更しました。

**修正前:**
```typescript
inputExtractor: (state) => ({
  outline: state.outline,
  editedDraft: state.editedDraft,
}),
```

**修正後:**
```typescript
inputExtractor: (state) => ({
  topic: state.topic,
  outline: state.outline,
  draft: state.draft,
  editedDraft: state.editedDraft,
  reviewCount: state.reviewCount ?? 0,
  maxReviews: state.maxReviews ?? 3,
}),
```

## Test plan

- [x] `bun run test` - 214件全て通過
- [x] `bun run type-check` - エラーなし
- [x] `bun run dev -- generate --topic "AIの未来" --max-reviews 1` - 正常実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)