### PR TITLE
refactor: 非推奨の logger.errorLegacy メソッドを削除

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -67,15 +67,6 @@ export class Logger {
     }
   }
 
-  /**
-   * 従来のエラーログ（可変長引数）
-   *
-   * @deprecated error(message, error) の使用を推奨
-   */
-  errorLegacy(...args: unknown[]): void {
-    if (this.shouldLog("error")) console.error("[ERROR]", ...args);
-  }
-
   warn(...args: unknown[]): void {
     if (this.shouldLog("warn")) console.warn("[WARN]", ...args);
   }


### PR DESCRIPTION
## Summary

- `src/logger.ts` から非推奨の `errorLegacy` メソッドを削除
- 呼び出し箇所がゼロのため安全に削除可能
- `error(message, error)` 形式の使用を推奨

## Test plan

- [x] `bun run test` - 370 tests passed
- [ ] `bun run type-check` - 既存の `src/env.ts` エラーあり（今回の変更とは無関係）
- [ ] `bun run build` - 既存の `src/env.ts` エラーあり（今回の変更とは無関係）

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)