### PR TITLE
refactor: 未使用のsearchResults/searchQueriesフィールドを削除 (Issue #31)

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -19,7 +19,4 @@ export const ArticleState = Annotation.Root({
   plannerRetryCount: Annotation<number>,
   writerRetryCount: Annotation<number>,
   editorRetryCount: Annotation<number>,
-  // Web検索関連
-  searchResults: Annotation<string>,
-  searchQueries: Annotation<string[]>,
 });


### PR DESCRIPTION
## Summary

- `ArticleState` から未使用だったWeb検索関連フィールドを削除
  - `searchResults: Annotation<string>`
  - `searchQueries: Annotation<string[]>`
- これらは `src/` ディレクトリ全体で一度も参照されていないため、YAGNI原則に従い削除

## Test plan

- [x] `bun test` で370テスト全て合格
- [x] `searchResults`/`searchQueries` の参照が0件であることを確認

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)