### PR TITLE
refactor: Researcher名称ハードコード除去とAgentConfig拡張 (Issue #33)

### DIFF
--- a/src/agents/agentFactory.ts
+++ b/src/agents/agentFactory.ts
@@ -84,6 +84,10 @@ export interface ToolEnabledAgentConfig<
 > extends AgentConfig<TInput, TRetryKey, TInputSchema> {
   /** 使用可能なツール配列（オプション） */
   tools?: Tool[];
+  /** 最小出力文字数（下回ればRETRY） */
+  minOutputLength?: number;
+  /** ツール使用を必須とするか */
+  requireToolUse?: boolean;
 }
 
 /**
@@ -556,6 +560,8 @@ export function createToolEnabledAgent<
     skipResponse,
     revisionConfig,
     tools = [],
+    minOutputLength = 0,
+    requireToolUse = false,
   } = config;
 
   // 改稿用プロンプトの事前構築（設定がある場合）
@@ -640,9 +646,15 @@ export function createToolEnabledAgent<
       logger.warn(`[${name}] ツールが指定されていますが、モデルはツールを呼び出しませんでした。`);
     }
 
-    // Researcherエージェント特別処理: ツールが使われず出力が短すぎる場合はRETRY
+    // 設定ベースの強制RETRY判定: ツールが使われず出力が短すぎる場合はRETRY
     let forceRetry = false;
-    if (name === "Researcher" && !toolCallsUsed && tools.length > 0 && content.length < 300) {
+    if (
+      requireToolUse &&
+      !toolCallsUsed &&
+      tools.length > 0 &&
+      minOutputLength > 0 &&
+      content.length < minOutputLength
+    ) {
       logger.warn(
         `[${name}] 出力が短すぎます（${content.length}文字）。ツール対応モデルの使用を推奨します。`,
       );

--- a/src/agents/researcher.ts
+++ b/src/agents/researcher.ts
@@ -26,6 +26,9 @@ const config: ToolEnabledAgentConfig<
     status: "planning",
   },
   tools: [webSearchTool as unknown as Tool, webFetchTool as unknown as Tool],
+  // ツール使用を必須とし、出力が300文字未満の場合はRETRY
+  minOutputLength: 300,
+  requireToolUse: true,
 };
 
 export const researcherNode = createToolEnabledAgent(config);


### PR DESCRIPTION
## 概要
Issue #33で指摘されていた `src/agents/agentFactory.ts` 行645の "Researcher" 文字列ハードコードを除去し、`AgentConfig` ベースの設定に移行しました。

## 変更内容

### 1. `ToolEnabledAgentConfig` にフィールド追加
```typescript
export interface ToolEnabledAgentConfig<...> {
  tools?: Tool[];
  minOutputLength?: number;  // 追加: 最小出力文字数（下回ればRETRY）
  requireToolUse?: boolean;  // 追加: ツール使用を必須とするか
}
```

### 2. "Researcher" 文字列比較を除去
- 修正前: `if (name === "Researcher" && !toolCallsUsed && tools.length > 0 && content.length < 300)`
- 修正後: `if (requireToolUse && !toolCallsUsed && tools.length > 0 && minOutputLength > 0 && content.length < minOutputLength)`

### 3. Researcherエージェント設定を更新
```typescript
const config: ToolEnabledAgentConfig<...> = {
  // ...
  tools: [webSearchTool, webFetchTool],
  minOutputLength: 300,
  requireToolUse: true,
};
```

## 動作確認
- ✅ `bun run type-check` - パス
- ✅ `bun run lint` - パス
- ✅ `bun test` - 389 pass / 0 fail

## 受入基準
- ✅ "Researcher" 文字列の直接比較が除去されている
- ✅ `AgentConfig` ベースの設定に移行されている
- ✅ 既存の動作が維持されている（後方互換性）
- ✅ 他のエージェントにも同様の設定が適用可能

closes #33